### PR TITLE
Add docs site and packaging

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs-material
+      - name: Build
+        run: mkdocs build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -1,30 +1,21 @@
-# Eudaimonia-
-Modular AI assistant with voice-aware behavior, dynamic mode switching, and Bahamian cultural tone. Built for real-world interaction, tactical decision-making, and emotional context.
+# Eudaimonia MCP
 
-## Requirements
+[![CI](https://github.com/OWNER/Eudaimonia-/actions/workflows/tests.yml/badge.svg)](https://github.com/OWNER/Eudaimonia-/actions/workflows/tests.yml)
+[![Docs](https://github.com/OWNER/Eudaimonia-/actions/workflows/docs.yml/badge.svg)](https://OWNER.github.io/Eudaimonia-/)
+[![TestPyPI](https://github.com/OWNER/Eudaimonia-/actions/workflows/release.yml/badge.svg)](https://test.pypi.org/project/eudaimonia-mcp/)
 
-The project relies solely on the Python standard library. Ensure Python 3.8 or newer is available. To run the test suite you will also need `pytest` installed:
+Eudaimonia MCP is a modular AI assistant with voice-aware behavior and dynamic mode switching, inspired by Bahamian culture.
+
+## Installation
 
 ```bash
-pip install pytest
+pip install eudaimonia-mcp
 ```
 
-## Running the assistant
-
-Use the module entry point located in `eudaimonia/main.py`:
+## Usage
 
 ```bash
 python -m eudaimonia.main
 ```
 
-This script initializes the assistant and processes several sample requests so you can confirm that everything is working.
-
-## Running the tests
-
-After the path fix, the test runner works without additional configuration. Execute:
-
-```bash
-pytest -q
-```
-
-At the moment no formal test cases are included so the command may report that zero tests were collected, but it should run successfully.
+For full documentation visit the project site.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Eudaimonia MCP
+
+**🇧🇸 Mindful computing with a Bahamian vibe.**
+
+Welcome to the documentation site for Eudaimonia MCP, a modular AI assistant that adapts its behavior through dynamic modes.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,8 @@
+# Modes
+
+Eudaimonia operates through several modes:
+
+- **DefaultMode** – baseline behavior.
+- **GuardianMode** – defensive stance.
+- **TacticalMode** – strategic planning.
+- **EmpathyMode** – emotionally aware interactions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,8 @@
+# Quickstart
+
+Install the package from TestPyPI and run the assistant:
+
+```bash
+pip install -i https://test.pypi.org/simple/ eudaimonia-mcp
+python -m eudaimonia.main
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: Eudaimonia MCP
+theme:
+  name: material
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Modes: modes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "eudaimonia-mcp"
+version = "0.1.0"
+description = "Modular AI assistant with dynamic modes and Bahamian cultural tone."
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Eudaimonia Team"}]
+license = {text = "MIT"}
+
+[project.urls]
+Homepage = "https://github.com/OWNER/Eudaimonia-"
+Documentation = "https://OWNER.github.io/Eudaimonia-/"
+
+[project.optional-dependencies]
+docs = ["mkdocs-material"]


### PR DESCRIPTION
## Summary
- package metadata in `pyproject.toml`
- docs configuration via `mkdocs.yml`
- add documentation pages
- update README with project badges
- deploy docs and manual release workflows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661a9e59208324a6141ec24940c7a3