### PR TITLE
Add YAML-driven Guardian rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ python -m eudaimonia.main
 ```
 
 For full documentation visit the project site.
+
+## Features
+
+- [Guardian Rules](docs/guardian_rules.md) - customize when Guardian mode activates.

--- a/docs/guardian_rules.md
+++ b/docs/guardian_rules.md
@@ -1,0 +1,11 @@
+# Guardian Rules
+
+Guardian mode activation is driven by rules in `config/guardian_rules.yml`.
+
+Each rule can specify:
+
+- `when_text_contains`: list of keywords triggering the rule when found in the user text.
+- `time_between`: start and end times in 24h format, evaluated in the user's timezone.
+- `context_requires`: context flags that must be truthy.
+
+Edit the YAML and reload the application to apply changes.

--- a/eudaimonia/config/guardian_rules.yml
+++ b/eudaimonia/config/guardian_rules.yml
@@ -1,0 +1,11 @@
+- id: distress_keywords
+  when_text_contains: ["help", "emergency", "intruder"]
+  action: trigger_guardian
+
+- id: night_watch
+  time_between: ["23:00", "05:00"]
+  action: trigger_guardian
+
+- id: family_only
+  context_requires: ["is_family_context"]
+  action: trigger_guardian

--- a/eudaimonia/core/rule_engine.py
+++ b/eudaimonia/core/rule_engine.py
@@ -1,0 +1,57 @@
+import os
+import yaml
+from datetime import datetime, time
+from zoneinfo import ZoneInfo
+
+DEFAULT_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "config", "guardian_rules.yml"
+)
+
+_rules_cache = None
+
+
+def load_rules(path: str = DEFAULT_PATH) -> list:
+    """Load rule definitions from YAML file."""
+    global _rules_cache
+    if _rules_cache is None:
+        with open(path, "r") as f:
+            _rules_cache = yaml.safe_load(f) or []
+    return _rules_cache
+
+
+def _in_time_range(now: datetime, start: str, end: str) -> bool:
+    start_t = time.fromisoformat(start)
+    end_t = time.fromisoformat(end)
+    now_t = now.timetz().replace(tzinfo=None)
+    if start_t <= end_t:
+        return start_t <= now_t <= end_t
+    return now_t >= start_t or now_t <= end_t
+
+
+def should_trigger_guardian(text: str, context: dict) -> bool:
+    """Evaluate loaded rules to decide whether guardian should trigger."""
+    text_lower = text.lower()
+    rules = load_rules()
+    tz = context.get("timezone")
+    if tz:
+        tzinfo = ZoneInfo(tz)
+    else:
+        tzinfo = datetime.now().astimezone().tzinfo
+    now = datetime.now(tzinfo)
+
+    for rule in rules:
+        if rule.get("action") != "trigger_guardian":
+            continue
+        if "when_text_contains" in rule:
+            keywords = rule["when_text_contains"]
+            if not any(word.lower() in text_lower for word in keywords):
+                continue
+        if "time_between" in rule:
+            start, end = rule["time_between"]
+            if not _in_time_range(now, start, end):
+                continue
+        if "context_requires" in rule:
+            if not all(context.get(flag) for flag in rule["context_requires"]):
+                continue
+        return True
+    return False

--- a/eudaimonia/modes/guardian_mode.py
+++ b/eudaimonia/modes/guardian_mode.py
@@ -1,12 +1,14 @@
 from ..core.tts import speak
 from ..core.base_mode import BaseMode
+from ..core.rule_engine import should_trigger_guardian
 
 class GuardianMode(BaseMode):
     name = "guardian_mode"
     tone = "protective"
 
     def should_trigger(self, context):
-        return context.get("is_family_context", False)
+        text = context.get("last_user_message", "")
+        return should_trigger_guardian(text, context)
 
     def process_request(self, request, context):
         response = (

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,3 +6,4 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - Modes: modes.md
+  - Guardian Rules: guardian_rules.md

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,33 @@
+import datetime as dt
+
+import pytest
+
+from eudaimonia.core import rule_engine
+
+
+def set_fixed_time(monkeypatch, hour, minute=0):
+    class FakeDateTime(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2021, 1, 1, hour, minute, tzinfo=tz)
+
+    monkeypatch.setattr(rule_engine, "datetime", FakeDateTime)
+
+
+def test_distress_keyword_triggers():
+    assert rule_engine.should_trigger_guardian("I need help now", {}) is True
+
+
+def test_night_watch_trigger(monkeypatch):
+    set_fixed_time(monkeypatch, 23, 30)
+    assert rule_engine.should_trigger_guardian("just checking", {}) is True
+
+
+def test_night_watch_non_trigger(monkeypatch):
+    set_fixed_time(monkeypatch, 6, 0)
+    assert rule_engine.should_trigger_guardian("morning", {}) is False
+
+
+def test_context_flag_triggers():
+    context = {"is_family_context": True}
+    assert rule_engine.should_trigger_guardian("", context) is True


### PR DESCRIPTION
## Summary
- externalize Guardian triggers to config/guardian_rules.yml
- add rule_engine for GuardianMode
- update GuardianMode to use rule engine
- document Guardian rules and update MkDocs navigation
- test Guardian rule evaluation
- list Guardian rules link in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68661dd81ba88324bfe366887254d2db