### PR TITLE
Add TinyDB memory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ For full documentation visit the project site.
 ## Features
 
 - [Guardian Rules](docs/guardian_rules.md) - customize when Guardian mode activates.
+- Memory store - TinyDB-based event log for agents and modes.

--- a/docs/memory_store.md
+++ b/docs/memory_store.md
@@ -1,0 +1,5 @@
+# Memory Store
+
+Eudaimonia keeps a lightweight event log using [TinyDB](https://tinydb.readthedocs.io/).
+Agents append events and modes can query them via `storage.py`.
+The database persists to a JSON file so context is kept between sessions.

--- a/eudaimonia/agents/__init__.py
+++ b/eudaimonia/agents/__init__.py
@@ -1,1 +1,6 @@
 """Agent implementations for the Eudaimonia package."""
+
+from .guardian_pulse_agent import GuardianPulseAgent
+from .empathy_checkin_agent import EmpathyCheckinAgent
+
+__all__ = ["GuardianPulseAgent", "EmpathyCheckinAgent"]

--- a/eudaimonia/agents/empathy_checkin_agent.py
+++ b/eudaimonia/agents/empathy_checkin_agent.py
@@ -1,0 +1,12 @@
+"""Agent that records user emotional check-ins."""
+
+from ..core.storage import append_event
+
+
+class EmpathyCheckinAgent:
+    """Log empathy-related events."""
+
+    def check_in(self, mood: str) -> str:
+        """Record the provided mood and return confirmation."""
+        append_event("empathy_check", {"mood": mood})
+        return "Mood logged"

--- a/eudaimonia/agents/guardian_pulse_agent.py
+++ b/eudaimonia/agents/guardian_pulse_agent.py
@@ -1,8 +1,13 @@
 """Placeholder Guardian Pulse Agent."""
 
+from ..core.storage import append_event
+
+
 class GuardianPulseAgent:
     """Simple health monitoring agent."""
 
     def check_pulse(self):
-        """Return a dummy status string."""
-        return "Pulse normal"
+        """Return a dummy status string and log the event."""
+        status = "Pulse normal"
+        append_event("guardian_check", {"status": status})
+        return status

--- a/eudaimonia/core/storage.py
+++ b/eudaimonia/core/storage.py
@@ -1,0 +1,35 @@
+import os
+from datetime import datetime
+from pathlib import Path
+from tinydb import TinyDB, Query
+
+DEFAULT_PATH = Path(__file__).resolve().parent / "memory.json"
+_db_cache = {}
+
+
+def _get_db(path=DEFAULT_PATH):
+    path = str(path)
+    if path not in _db_cache:
+        _db_cache[path] = TinyDB(path)
+    return _db_cache[path]
+
+
+def append_event(event_type: str, data: dict, *, path: str = DEFAULT_PATH) -> None:
+    """Append an event dict to the TinyDB store."""
+    db = _get_db(path)
+    db.insert({"type": event_type, "data": data, "ts": datetime.utcnow().isoformat()})
+
+
+def get_recent_events(event_type: str, limit: int = 10, *, path: str = DEFAULT_PATH) -> list:
+    """Return up to ``limit`` most recent events of ``event_type``."""
+    db = _get_db(path)
+    q = Query()
+    events = db.search(q.type == event_type)
+    events.sort(key=lambda e: e.get("ts", ""), reverse=True)
+    return events[:limit]
+
+
+def clear_store(*, path: str = DEFAULT_PATH) -> None:
+    """Utility to clear all events in the store (mainly for tests)."""
+    db = _get_db(path)
+    db.truncate()

--- a/eudaimonia/modes/default_mode.py
+++ b/eudaimonia/modes/default_mode.py
@@ -1,12 +1,18 @@
 from ..core.tts import speak
 from ..core.base_mode import BaseMode
+from ..core.storage import get_recent_events
 
 class DefaultMode(BaseMode):
     name = "default"
     tone = "bahamian_female_freeport"
 
     def on_activate(self, context):
-        print("Default mode activated. Speaking in Freeport Bahamian tone.")
+        events = get_recent_events("empathy_check", 1)
+        if events:
+            mood = events[0]["data"].get("mood")
+            print(f"Welcome back. Last mood was {mood}.")
+        else:
+            print("Default mode activated. Speaking in Freeport Bahamian tone.")
 
     def process_request(self, request, context):
         response = (

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,3 +7,4 @@ nav:
   - Quickstart: quickstart.md
   - Modes: modes.md
   - Guardian Rules: guardian_rules.md
+  - Memory Store: memory_store.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ requires-python = ">=3.8"
 authors = [{name = "Eudaimonia Team"}]
 license = {text = "MIT"}
 
+dependencies = [
+    "tinydb"
+]
+
 [project.urls]
 Homepage = "https://github.com/OWNER/Eudaimonia-"
 Documentation = "https://OWNER.github.io/Eudaimonia-/"

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,10 @@
+import os
+from eudaimonia.core import storage
+
+
+def test_memory_round_trip(tmp_path):
+    db_file = tmp_path / "mem.json"
+    storage.append_event("test", {"value": 1}, path=str(db_file))
+    events = storage.get_recent_events("test", path=str(db_file))
+    assert len(events) == 1
+    assert events[0]["data"]["value"] == 1


### PR DESCRIPTION
## Summary
- implement a TinyDB-backed storage helper
- log events from GuardianPulseAgent and new EmpathyCheckinAgent
- DefaultMode greets using last empathy check
- document the memory store and link in MkDocs
- add dependency on tinydb
- include tests for the memory store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670182ca008324864251b02eeae5e8