### PR TITLE
Add FastAPI bridge & Dockerfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install .[docs] fastapi uvicorn pytest httpx
+      - name: Run tests
+        run: pytest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install .[docs] fastapi uvicorn
+CMD ["uvicorn", "eudaimonia.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ For full documentation visit the project site.
 
 - [Guardian Rules](docs/guardian_rules.md) - customize when Guardian mode activates.
 - Memory store - TinyDB-based event log for agents and modes.
+- API bridge - interact with the assistant over HTTP.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,14 @@
+# API Bridge
+
+Eudaimonia exposes a lightweight HTTP interface using FastAPI. This makes it easy to integrate the assistant with other services.
+
+## Endpoints
+
+### `POST /speak`
+Send JSON `{ "text": "hello" }` to invoke the text‑to‑speech helper.
+
+### `POST /mode`
+Provide `{ "mode": "mode_name" }` to switch the active mode programmatically.
+
+### `GET /log`
+Query parameters `type` and optional `limit` return recent events from the memory store.

--- a/eudaimonia/api.py
+++ b/eudaimonia/api.py
@@ -1,0 +1,34 @@
+from fastapi import FastAPI, HTTPException
+
+from .core import tts, storage
+from .core.eudaimonia import Eudaimonia
+from .core.mode_manager import ModeManager
+
+assistant = Eudaimonia()
+mode_manager: ModeManager = assistant.mode_manager
+
+app = FastAPI()
+
+
+@app.post("/speak")
+async def speak(payload: dict):
+    text = payload.get("text")
+    if not isinstance(text, str):
+        raise HTTPException(status_code=400, detail="text field required")
+    tts.speak(text)
+    return {"status": "ok"}
+
+
+@app.post("/mode")
+async def switch_mode(payload: dict):
+    mode = payload.get("mode")
+    if not isinstance(mode, str):
+        raise HTTPException(status_code=400, detail="mode field required")
+    changed = mode_manager.switch_mode(mode)
+    return {"active_mode": mode_manager.current_mode.name, "changed": changed}
+
+
+@app.get("/log")
+async def get_log(type: str, limit: int = 10):
+    events = storage.get_recent_events(type, limit)
+    return events

--- a/eudaimonia/core/mode_manager.py
+++ b/eudaimonia/core/mode_manager.py
@@ -25,5 +25,9 @@ class ModeManager:
         self.current_mode.on_activate({})
         return True
 
+    def switch_mode(self, mode_name):
+        """Public helper to switch modes programmatically."""
+        return self.try_switch_to_mode(mode_name)
+
     def fallback_mode(self):
         self.try_switch_to_mode(self.default_mode.name)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,4 @@ nav:
   - Modes: modes.md
   - Guardian Rules: guardian_rules.md
   - Memory Store: memory_store.md
+  - API: api.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,45 @@
+from fastapi.testclient import TestClient
+
+from eudaimonia.api import app, mode_manager
+from eudaimonia.core import tts, storage
+
+client = TestClient(app)
+
+
+def test_speak_endpoint(monkeypatch):
+    spoken = {}
+
+    def fake_speak(text: str):
+        spoken['text'] = text
+
+    monkeypatch.setattr(tts, 'speak', fake_speak)
+    res = client.post('/speak', json={'text': 'hello'})
+    assert res.status_code == 200
+    assert res.json() == {'status': 'ok'}
+    assert spoken['text'] == 'hello'
+
+
+def test_mode_endpoint():
+    res = client.post('/mode', json={'mode': 'default'})
+    assert res.status_code == 200
+    assert res.json()['active_mode'] == 'default'
+    assert mode_manager.current_mode.name == 'default'
+
+
+def test_log_endpoint(tmp_path, monkeypatch):
+    db_file = tmp_path / 'events.json'
+    storage._db_cache = {}
+    storage.append_event('test', {'value': 42}, path=str(db_file))
+
+    orig = storage.get_recent_events
+
+    def fake_get_recent(event_type: str, limit: int = 10):
+        return orig(event_type, limit, path=str(db_file))
+
+    monkeypatch.setattr(storage, 'get_recent_events', fake_get_recent)
+
+    res = client.get('/log', params={'type': 'test', 'limit': 1})
+    assert res.status_code == 200
+    data = res.json()
+    assert isinstance(data, list)
+    assert data[0]['data']['value'] == 42


### PR DESCRIPTION
## Summary
- add FastAPI API bridge with `/speak`, `/mode`, and `/log` endpoints
- include Dockerfile to run the web server
- document API and expose it in mkdocs
- add CI workflow for running tests
- test API endpoints
- mention API bridge in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68670f2781788324bc5bac2bb30e7c52