### PR TITLE
Add security and compliance configs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,9 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [main]
+  pull_request:
+jobs:
+  analyze:
+    name: Analyze (CodeQL)
+    uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+.DS_Store
+*.json
+!memory.json
+.secrets.baseline
+/dist/
+/build/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Olympianthunder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add MIT LICENSE for Olympianthunder
- ignore build artifacts and Python cache
- enable Dependabot for pip
- set flake8 style rules
- run GitHub CodeQL on pushes and pull requests

## Testing
- `pip install .[docs] fastapi uvicorn pytest httpx`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68672303c0f88324aac290017d8f4f84