### PR TITLE
Add state persistence docs

### DIFF
--- a/docs/state_persistence.md
+++ b/docs/state_persistence.md
@@ -1,0 +1,17 @@
+# State Persistence
+
+Eudaimonia Core uses DataJar for explicit state saves and restores. Shortcuts can call the API to capture or reload the current state JSON.
+
+## Endpoints
+- `GET /get_state_to_save` – return the current mode and other state fields.
+- `POST /update_eudaimonia_state` – accept JSON to rehydrate Eudaimonia Core.
+
+## Workflow
+1. **Save** – Shortcut `Save Eudaimonia State` calls the GET endpoint and stores the JSON in DataJar.
+2. **Load** – Shortcut `Load Eudaimonia State` retrieves the JSON from DataJar and POSTs to the update endpoint.
+3. *(Optional)* Automations can run daily at set times to persist and restore state.
+
+## Next Steps
+- Merge these docs under feature/state-persistence.
+- Build and test the Shortcuts end-to-end.
+- Explore push-based triggers later.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,4 +8,5 @@ nav:
   - Modes: modes.md
   - Guardian Rules: guardian_rules.md
   - Memory Store: memory_store.md
+  - State Persistence: state_persistence.md
   - API: api.md


### PR DESCRIPTION
## Summary
- document state persistence design using DataJar
- link the new doc in the MkDocs nav

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4a13b0ec83249cd9942efb42fb8a