### PR TITLE
Add vault loader, CI security scan and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install .[docs] fastapi uvicorn pytest httpx
+      - name: Run tests
+        run: pytest -v
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install python tools
+        run: pip install bandit
+      - name: Bandit scan
+        run: bandit -r . -ll
+      - name: NPM audit
+        run: |
+          if [ -f package.json ]; then
+            npm install
+            npm audit --audit-level=high
+          else
+            echo "No frontend package.json found"
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Eudaimonia MCP
+
+Thank you for wanting to contribute! This project uses **pre-commit** to ensure
+a consistent code style and to prevent accidental commits of secrets.
+
+## Setup
+
+1. Install the pre-commit tool:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the git hooks:
+   ```bash
+   pre-commit install
+   ```
+   The hooks will run automatically on each commit.
+
+If a hook fails, fix the reported issues and re-run `git commit`.

--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ For full documentation visit the project site.
 - [Guardian Rules](docs/guardian_rules.md) - customize when Guardian mode activates.
 - Memory store - TinyDB-based event log for agents and modes.
 - API bridge - interact with the assistant over HTTP.
+- Automated security scanning with Bandit, npm audit and pre-commit hooks.
+
+## Development
+
+Install the pre-commit hooks to run linters and secret checks automatically:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/backend/config/secure_loader.py
+++ b/backend/config/secure_loader.py
@@ -1,0 +1,33 @@
+from functools import lru_cache
+import os
+import json
+
+import hvac
+
+
+@lru_cache
+def get_secret(key: str) -> str:
+    """Retrieve ``key`` from HashiCorp Vault if available.
+
+    Falls back to local ``local_settings.json`` or environment variables
+    when Vault credentials are not provided.
+    """
+    vault_addr = os.getenv("VAULT_ADDR")
+    vault_token = os.getenv("VAULT_TOKEN")
+    if vault_addr and vault_token:
+        client = hvac.Client(url=vault_addr, token=vault_token)
+        secret = client.secrets.kv.v2.read_secret_version(path=f"eudaimonia/{key}")
+        return secret["data"]["data"][key]
+
+    # Fallback to local settings file
+    local_cfg = os.path.join(os.path.dirname(__file__), "local_settings.json")
+    if os.path.exists(local_cfg):
+        with open(local_cfg) as f:
+            data = json.load(f)
+            if key in data:
+                return data[key]
+
+    value = os.getenv(key.upper())
+    if value is not None:
+        return value
+    raise KeyError(f"Secret '{key}' not found")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,7 @@ Documentation = "https://OWNER.github.io/Eudaimonia-/"
 
 [project.optional-dependencies]
 docs = ["mkdocs-material"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+exclude = ["backend*", "tests*"]


### PR DESCRIPTION
## Summary
- add secure Vault loader with environment fallback
- enforce security scanning with Bandit and npm audit in CI
- add pre-commit config with black, flake8 and detect-secrets
- document contribution workflow and security scanning

## Testing
- `pip install .[docs] fastapi uvicorn pytest httpx`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_686c4f5a73a48324b604f69318a1f5e8