### PR TITLE
feat: add TaskAutomation + security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install .[docs] fastapi uvicorn pytest httpx jsonschema ruff black pip-audit bandit
+          npm install eslint@latest --save-dev
+      - name: Lint Python
+        run: |
+          ruff check .
+          black . --check
+      - name: Lint JS
+        run: npx eslint . --ext .js,.ts --no-error-on-unmatched-pattern
+      - name: Run tests
+        run: pytest -q
+      - name: Python vuln scan
+        run: |
+          pip install pip-audit
+          pip-audit --fail-on high
+      - name: Node vuln scan
+        working-directory: frontend
+        run: npm audit --audit-level=moderate
+      - name: Bandit security scan
+        run: |
+          pip install bandit
+          bandit -r backend/ -ll

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ __pycache__/
 .DS_Store
 *.json
 !memory.json
+.coverage
+node_modules/
 .secrets.baseline
 /dist/
 /build/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+title = "eudaimonia rules"
+[allowlist]
+  description = "Allow nothing special"
+  regexes = []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-json
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+        args: ["--rules-path=.gitleaks.toml"]

--- a/README.md
+++ b/README.md
@@ -25,3 +25,24 @@ For full documentation visit the project site.
 - [Guardian Rules](docs/guardian_rules.md) - customize when Guardian mode activates.
 - Memory store - TinyDB-based event log for agents and modes.
 - API bridge - interact with the assistant over HTTP.
+
+## Task Automation
+
+New endpoints provide automated task suggestions and execution:
+
+```python
+from backend.api import app
+```
+
+POST `/tasks/suggest` with `{"goal": "report"}` returns matching tasks.
+POST `/tasks/execute` executes an approved task.
+
+## Security
+
+Secrets are pulled from Vault using `get_secret()` and never stored in code.
+Pre-commit hooks can be enabled with:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for MCP."""

--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+
+from .tasks import router as tasks_router
+
+app = FastAPI()
+app.include_router(tasks_router)

--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, HTTPException
+from typing import Any, Dict
+
+from ..mcp_controller import (
+    dispatcher,
+    planner,
+    TaskSpec,
+    ErrorPolicy,
+)
+
+router = APIRouter(prefix="/tasks")
+
+
+@router.post("/suggest")
+async def suggest(payload: Dict[str, Any]):
+    goal = payload.get("goal", "")
+    context = payload.get("context", {})
+    tasks = planner.suggest_tasks(goal, context)
+    return [t.dict() for t in tasks]
+
+
+@router.post("/execute")
+async def execute(payload: Dict[str, Any]):
+    try:
+        task = TaskSpec(**payload.get("task", {}))
+        params = payload.get("params", {})
+        policy = ErrorPolicy(**payload.get("policy", {}))
+        context = payload.get("context", {})
+    except Exception as exc:  # pragma: no cover - basic validation
+        raise HTTPException(status_code=400, detail=str(exc))
+    try:
+        result = dispatcher.dispatch(task, params, policy, context)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return result

--- a/backend/config/secure_loader.py
+++ b/backend/config/secure_loader.py
@@ -1,0 +1,16 @@
+from functools import lru_cache
+import hvac
+import os
+
+
+@lru_cache
+def get_secret(key: str) -> str:
+    vault_addr = os.environ["VAULT_ADDR"]
+    vault_token = os.environ["VAULT_TOKEN"]
+    client = hvac.Client(url=vault_addr, token=vault_token)
+    data = client.secrets.kv.v2.read_secret_version(path=f"eudaimonia/{key}")["data"][
+        "data"
+    ]
+    if key not in data:
+        raise RuntimeError(f"Missing secret: {key}")
+    return data[key]

--- a/backend/mcp_controller.py
+++ b/backend/mcp_controller.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import jsonschema
+from pydantic import BaseModel
+from typing import Any, Dict, List, Literal
+import time
+from eudaimonia.core import storage
+
+
+class TaskSpec(BaseModel):
+    id: str
+    label: str
+    description: str
+    params_schema: Dict[str, Any]
+    schedule: str
+    risk: Literal["low", "medium", "high"]
+    idempotent: bool
+
+
+class ErrorPolicy(BaseModel):
+    retry: int = 0
+    retry_delay: str = "0"
+    notify: bool = False
+    abort_on_failure: bool = True
+    alert_level: str = "info"
+
+
+class Planner:
+    def __init__(self) -> None:
+        events = storage.get_recent_events("task_automation", limit=100)
+        self.tasks: List[TaskSpec] = [TaskSpec(**e["data"]) for e in events]
+
+    def suggest_tasks(self, goal: str, context: Dict[str, Any]) -> List[TaskSpec]:
+        matches = []
+        gl = goal.lower()
+        for task in self.tasks:
+            if gl in task.description.lower() or gl in task.label.lower():
+                matches.append(task)
+        return matches
+
+
+class ExecutionEngine:
+    def __init__(self) -> None:
+        self.executed: set[str] = set()
+
+    def _validate(self, task: TaskSpec, params: Dict[str, Any]) -> None:
+        jsonschema.validate(params, task.params_schema)
+
+    def execute(
+        self, task: TaskSpec, params: Dict[str, Any], policy: ErrorPolicy
+    ) -> Dict[str, Any]:
+        if task.idempotent and task.id in self.executed:
+            return {"status": "skipped", "reason": "idempotent"}
+        self._validate(task, params)
+        attempt = 0
+        while True:
+            try:
+                result = {"task": task.id, "params": params, "status": "success"}
+                storage.append_event("task_exec", {"task": task.id, "params": params})
+                break
+            except Exception as exc:  # pragma: no cover - example placeholder
+                attempt += 1
+                if attempt > policy.retry or policy.abort_on_failure:
+                    raise exc
+                time.sleep(float(policy.retry_delay))
+        self.executed.add(task.id)
+        return result
+
+
+class Dispatcher:
+    def __init__(self, engine: ExecutionEngine) -> None:
+        self.engine = engine
+
+    def dispatch(
+        self,
+        task: TaskSpec,
+        params: Dict[str, Any],
+        policy: ErrorPolicy,
+        context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        if task.risk in {"low", "medium"}:
+            approved = True
+        else:
+            approved = context.get("guardian_confirmed", False)
+            if not approved:
+                raise PermissionError("GuardianMode confirmation required")
+        return self.engine.execute(task, params, policy)
+
+
+planner = Planner()
+engine = ExecutionEngine()
+dispatcher = Dispatcher(engine)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,24 @@
+# Security
+
+## Vault-backed Secrets
+
+Secrets are loaded at runtime via HashiCorp Vault. Use `backend/config/secure_loader.py` and call `get_secret('KEY')` to access stored secrets. This removes the need for plaintext environment variables.
+
+## CI Security Scans
+
+The CI workflow runs dependency vulnerability checks for Python and Node packages and executes Bandit to scan the backend codebase:
+
+```
+pip-audit --fail-on high
+npm audit --audit-level=moderate
+bandit -r backend/ -ll
+```
+
+## Pre-commit Hooks
+
+Pre-commit hooks prevent accidental inclusion of secrets or malformed files. Install them once per clone:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  ignores: ['node_modules/**']
+};

--- a/eudaimonia/core/eudaimonia.py
+++ b/eudaimonia/core/eudaimonia.py
@@ -4,15 +4,11 @@ from ..modes.guardian_mode import GuardianMode
 from ..modes.tactical_mode import TacticalMode
 from ..modes.empathy_mode import EmpathyMode
 
+
 class Eudaimonia:
     def __init__(self):
         self.default_mode = DefaultMode()
-        self.modes = [
-            self.default_mode,
-            GuardianMode(),
-            TacticalMode(),
-            EmpathyMode()
-        ]
+        self.modes = [self.default_mode, GuardianMode(), TacticalMode(), EmpathyMode()]
         self.mode_manager = ModeManager(self.modes, self.default_mode)
 
     def process_request(self, request, context):

--- a/eudaimonia/core/storage.py
+++ b/eudaimonia/core/storage.py
@@ -1,4 +1,3 @@
-import os
 from datetime import datetime
 from pathlib import Path
 from tinydb import TinyDB, Query
@@ -20,7 +19,9 @@ def append_event(event_type: str, data: dict, *, path: str = DEFAULT_PATH) -> No
     db.insert({"type": event_type, "data": data, "ts": datetime.utcnow().isoformat()})
 
 
-def get_recent_events(event_type: str, limit: int = 10, *, path: str = DEFAULT_PATH) -> list:
+def get_recent_events(
+    event_type: str, limit: int = 10, *, path: str = DEFAULT_PATH
+) -> list:
     """Return up to ``limit`` most recent events of ``event_type``."""
     db = _get_db(path)
     q = Query()

--- a/eudaimonia/core/voice_manager.py
+++ b/eudaimonia/core/voice_manager.py
@@ -5,8 +5,9 @@ CONFIG_PATH = os.path.join(
     os.path.dirname(__file__), "..", "config", "voice_profiles.json"
 )
 
-with open(CONFIG_PATH, 'r') as f:
+with open(CONFIG_PATH, "r") as f:
     voice_profiles = json.load(f)
+
 
 def get_voice_profile(mode_name):
     if mode_name in voice_profiles:

--- a/eudaimonia/main.py
+++ b/eudaimonia/main.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
         {"is_family_context": True, "request": "Check on the kids."},
         {"user_entered_tactical_command": True, "request": "Run safety protocol."},
         {"emotion_hint": "anxious", "request": "I feel overwhelmed."},
-        {"request": "What's for dinner?"}
+        {"request": "What's for dinner?"},
     ]
 
     for context in test_contexts:

--- a/eudaimonia/modes/default_mode.py
+++ b/eudaimonia/modes/default_mode.py
@@ -2,6 +2,7 @@ from ..core.tts import speak
 from ..core.base_mode import BaseMode
 from ..core.storage import get_recent_events
 
+
 class DefaultMode(BaseMode):
     name = "default"
     tone = "bahamian_female_freeport"
@@ -15,8 +16,6 @@ class DefaultMode(BaseMode):
             print("Default mode activated. Speaking in Freeport Bahamian tone.")
 
     def process_request(self, request, context):
-        response = (
-            f"[DefaultMode - Bahamian Voice] I get you, {request}. Let’s handle it, aye."
-        )
+        response = f"[DefaultMode - Bahamian Voice] I get you, {request}. Let’s handle it, aye."
         speak(response)
         return response

--- a/eudaimonia/modes/empathy_mode.py
+++ b/eudaimonia/modes/empathy_mode.py
@@ -1,6 +1,7 @@
 from ..core.tts import speak
 from ..core.base_mode import BaseMode
 
+
 class EmpathyMode(BaseMode):
     name = "empathy_mode"
     tone = "supportive"

--- a/eudaimonia/modes/guardian_mode.py
+++ b/eudaimonia/modes/guardian_mode.py
@@ -2,6 +2,7 @@ from ..core.tts import speak
 from ..core.base_mode import BaseMode
 from ..core.rule_engine import should_trigger_guardian
 
+
 class GuardianMode(BaseMode):
     name = "guardian_mode"
     tone = "protective"

--- a/eudaimonia/modes/tactical_mode.py
+++ b/eudaimonia/modes/tactical_mode.py
@@ -1,6 +1,7 @@
 from ..core.tts import speak
 from ..core.base_mode import BaseMode
 
+
 class TacticalMode(BaseMode):
     name = "tactical_mode"
     tone = "straightforward"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = [{name = "Eudaimonia Team"}]
 license = {text = "MIT"}
 
 dependencies = [
-    "tinydb"
+    "tinydb",
+    "hvac"
 ]
 
 [project.urls]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,36 +10,36 @@ def test_speak_endpoint(monkeypatch):
     spoken = {}
 
     def fake_speak(text: str):
-        spoken['text'] = text
+        spoken["text"] = text
 
-    monkeypatch.setattr(tts, 'speak', fake_speak)
-    res = client.post('/speak', json={'text': 'hello'})
+    monkeypatch.setattr(tts, "speak", fake_speak)
+    res = client.post("/speak", json={"text": "hello"})
     assert res.status_code == 200
-    assert res.json() == {'status': 'ok'}
-    assert spoken['text'] == 'hello'
+    assert res.json() == {"status": "ok"}
+    assert spoken["text"] == "hello"
 
 
 def test_mode_endpoint():
-    res = client.post('/mode', json={'mode': 'default'})
+    res = client.post("/mode", json={"mode": "default"})
     assert res.status_code == 200
-    assert res.json()['active_mode'] == 'default'
-    assert mode_manager.current_mode.name == 'default'
+    assert res.json()["active_mode"] == "default"
+    assert mode_manager.current_mode.name == "default"
 
 
 def test_log_endpoint(tmp_path, monkeypatch):
-    db_file = tmp_path / 'events.json'
+    db_file = tmp_path / "events.json"
     storage._db_cache = {}
-    storage.append_event('test', {'value': 42}, path=str(db_file))
+    storage.append_event("test", {"value": 42}, path=str(db_file))
 
     orig = storage.get_recent_events
 
     def fake_get_recent(event_type: str, limit: int = 10):
         return orig(event_type, limit, path=str(db_file))
 
-    monkeypatch.setattr(storage, 'get_recent_events', fake_get_recent)
+    monkeypatch.setattr(storage, "get_recent_events", fake_get_recent)
 
-    res = client.get('/log', params={'type': 'test', 'limit': 1})
+    res = client.get("/log", params={"type": "test", "limit": 1})
     assert res.status_code == 200
     data = res.json()
     assert isinstance(data, list)
-    assert data[0]['data']['value'] == 42
+    assert data[0]["data"]["value"] == 42

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,4 +1,3 @@
-import os
 from eudaimonia.core import storage
 
 

--- a/tests/test_mode_manager.py
+++ b/tests/test_mode_manager.py
@@ -1,5 +1,3 @@
-import pytest
-
 from eudaimonia.core.base_mode import BaseMode
 from eudaimonia.core.mode_manager import ModeManager
 
@@ -57,4 +55,3 @@ def test_switch_back_to_default_on_deactivate():
     assert manager.current_mode is default
     assert dummy.deactivated == 1
     assert default.activated == 2
-

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,7 +1,5 @@
 import datetime as dt
 
-import pytest
-
 from eudaimonia.core import rule_engine
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from backend.api import app
+from backend.mcp_controller import TaskSpec, ErrorPolicy, planner, engine
+from eudaimonia.core import storage
+
+client = TestClient(app)
+
+
+def test_suggest_empty(monkeypatch):
+    monkeypatch.setattr(planner, "tasks", [])
+    res = client.post("/tasks/suggest", json={"goal": "foo"})
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+def test_execute_flow(tmp_path, monkeypatch):
+    task = TaskSpec(
+        id="t1",
+        label="demo",
+        description="demo task",
+        params_schema={
+            "type": "object",
+            "properties": {"x": {"type": "number"}},
+            "required": ["x"],
+        },
+        schedule="now",
+        risk="low",
+        idempotent=True,
+    )
+    monkeypatch.setattr(engine, "executed", set())
+    storage._db_cache = {}
+    res = client.post(
+        "/tasks/execute",
+        json={
+            "task": task.dict(),
+            "params": {"x": 1},
+            "policy": ErrorPolicy(retry=0).dict(),
+            "context": {},
+        },
+    )
+    assert res.status_code == 200
+    assert res.json()["status"] == "success"


### PR DESCRIPTION
## Summary
- add Vault-backed secret loader
- scaffold TaskAutomation subsystem with planner, engine and dispatcher
- provide FastAPI endpoints for suggesting and executing tasks
- run security scans in CI
- configure pre-commit hooks with gitleaks
- document security setup and task automation usage

## Testing
- `ruff check . --exclude node_modules`
- `black . --exclude node_modules --check`
- `npx eslint . --ext .js,.ts --no-error-on-unmatched-pattern`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c50703ba083249d66f0c380fb9677