### PR TITLE
Add persistent memory layer and dialogue loop

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+model: gpt-4o-mini
+ctx_window: 16
+encrypt: true
+memory_path: memory

--- a/eudaimonia/cli/main_loop.py
+++ b/eudaimonia/cli/main_loop.py
@@ -1,0 +1,49 @@
+"""Interactive shell entrypoint with YAML config."""
+
+from __future__ import annotations
+
+import argparse
+import yaml
+
+from ..core.memory_store import MemoryStore
+from ..core.dialogue_loop import DialogueLoop
+
+
+def load_config(path: str) -> dict:
+    with open(path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Eudaimonia interactive loop")
+    parser.add_argument('--config', default='config.yaml', help='Path to YAML config')
+    parser.add_argument('--model', help='Override model from config')
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    if args.model:
+        cfg['model'] = args.model
+
+    store = MemoryStore(cfg.get('memory_path', 'memory'), encrypt=cfg.get('encrypt', False))
+    loop = DialogueLoop(store, model=cfg.get('model', 'gpt-4o-mini'))
+
+    loop.start_session()
+    try:
+        while True:
+            try:
+                msg = input('> ')
+            except EOFError:
+                break
+            if msg.strip().lower() in {'exit', 'quit'}:
+                break
+            loop.record_exchange('user', msg)
+            response = f"echo: {msg}"
+            print(response)
+            loop.record_exchange('assistant', response)
+    finally:
+        sid = loop.close_session()
+        print(f"Session saved as {sid}")
+
+
+if __name__ == '__main__':
+    main()

--- a/eudaimonia/core/__init__.py
+++ b/eudaimonia/core/__init__.py
@@ -1,1 +1,6 @@
 """Core functionality for the Eudaimonia package."""
+
+from .memory_store import MemoryStore
+from .dialogue_loop import DialogueLoop
+
+__all__ = ["MemoryStore", "DialogueLoop"]

--- a/eudaimonia/core/dialogue_loop.py
+++ b/eudaimonia/core/dialogue_loop.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Dict
+
+import numpy as np
+import openai
+
+from .memory_store import MemoryStore
+
+
+class DialogueLoop:
+    """Simple controller for a text dialogue session."""
+
+    def __init__(self, store: MemoryStore, *, model: str = "text-embedding-ada-002"):
+        self.store = store
+        self.model = model
+        self.session: List[Dict[str, str]] = []
+
+    def start_session(self) -> None:
+        self.session = []
+
+    def record_exchange(self, speaker: str, text: str) -> None:
+        self.session.append({"speaker": speaker, "text": text})
+
+    def close_session(self) -> str:
+        session_id = datetime.utcnow().isoformat(timespec="seconds").replace(":", "-")
+        self.store.put(session_id, self.session, fmt="json")
+        joined = " ".join(item["text"] for item in self.session)
+        resp = openai.Embedding.create(input=joined, model=self.model)
+        embedding = resp["data"][0]["embedding"]
+        self.store.put(f"{session_id}_emb", np.array(embedding, dtype=float), fmt="npy")
+        return session_id

--- a/eudaimonia/core/memory_store.py
+++ b/eudaimonia/core/memory_store.py
@@ -1,0 +1,87 @@
+import io
+import json
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import yaml
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class MemoryStore:
+    """Filesystem backed key-value store with optional Fernet encryption."""
+
+    def __init__(self, path: str | Path, *, encrypt: bool = False, key: bytes | None = None):
+        self.base_path = Path(path)
+        self.base_path.mkdir(parents=True, exist_ok=True)
+        self.encrypt = encrypt
+        self.fernet = None
+        if encrypt:
+            self.fernet = Fernet(key or Fernet.generate_key())
+
+    def get_key(self) -> bytes | None:
+        if self.fernet:
+            return self.fernet._signing_key + self.fernet._encryption_key
+        return None
+
+    # util
+    def _file(self, key: str, ext: str) -> Path:
+        return self.base_path / f"{key}.{ext}"
+
+    def _write(self, path: Path, data: bytes) -> None:
+        if path.exists():
+            backup = path.with_suffix(path.suffix + ".bak")
+            path.replace(backup)
+        if self.encrypt and self.fernet:
+            data = self.fernet.encrypt(data)
+        path.write_bytes(data)
+
+    def _read(self, path: Path) -> bytes:
+        data = path.read_bytes()
+        if self.encrypt and self.fernet:
+            try:
+                data = self.fernet.decrypt(data)
+            except InvalidToken as e:
+                raise ValueError("Invalid encryption key") from e
+        return data
+
+    # public API
+    def put(self, key: str, value: Any, *, fmt: str = "json") -> Path:
+        path = self._file(key, "yaml" if fmt == "yaml" else ("npy" if fmt == "npy" else "json"))
+        if fmt == "json":
+            raw = json.dumps(value).encode()
+        elif fmt == "yaml":
+            raw = yaml.safe_dump(value).encode()
+        elif fmt == "npy":
+            buf = io.BytesIO()
+            np.save(buf, value)
+            raw = buf.getvalue()
+        else:
+            raise ValueError(f"unknown format {fmt}")
+        self._write(path, raw)
+        return path
+
+    def get(self, key: str, *, fmt: str = "json", default: Any | None = None) -> Any:
+        path = self._file(key, "yaml" if fmt == "yaml" else ("npy" if fmt == "npy" else "json"))
+        if not path.exists():
+            return default
+        raw = self._read(path)
+        if fmt == "json":
+            return json.loads(raw.decode())
+        elif fmt == "yaml":
+            return yaml.safe_load(raw.decode())
+        elif fmt == "npy":
+            buf = io.BytesIO(raw)
+            return np.load(buf, allow_pickle=True)
+        else:
+            raise ValueError(f"unknown format {fmt}")
+
+    def keys(self) -> Iterable[str]:
+        for p in self.base_path.glob('*'):
+            if p.suffix == '.bak' or not p.is_file():
+                continue
+            yield p.stem
+
+    def reset(self) -> None:
+        for p in self.base_path.glob('*'):
+            p.unlink()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+openai>=1.3.0
+cryptography>=42.0
+pyyaml>=6.0
+numpy>=1.26
+pytest>=8.0

--- a/tests/test_dialogue_loop.py
+++ b/tests/test_dialogue_loop.py
@@ -1,0 +1,27 @@
+import numpy as np
+import openai
+
+from eudaimonia.core.memory_store import MemoryStore
+from eudaimonia.core.dialogue_loop import DialogueLoop
+
+
+def test_close_session_stores_embedding(monkeypatch, tmp_path):
+    store = MemoryStore(tmp_path)
+    called = {}
+
+    def fake_create(input, model):
+        called['input'] = input
+        return {'data': [{'embedding': [0.1, 0.2, 0.3]}]}
+
+    monkeypatch.setattr(openai.Embedding, 'create', fake_create)
+
+    loop = DialogueLoop(store, model='fake-model')
+    loop.start_session()
+    loop.record_exchange('user', 'hi')
+    loop.record_exchange('assistant', 'hello')
+    sid = loop.close_session()
+
+    assert store.get(sid)[0]['text'] == 'hi'
+    emb = store.get(f'{sid}_emb', fmt='npy')
+    assert np.allclose(emb, [0.1, 0.2, 0.3])
+    assert called['input'] == 'hi hello'

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,24 @@
+import numpy as np
+from eudaimonia.core.memory_store import MemoryStore
+
+
+def test_round_trip_json_yaml_npy(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.put('j', {'a': 1})
+    assert store.get('j') == {'a': 1}
+
+    store.put('y', {'b': 2}, fmt='yaml')
+    assert store.get('y', fmt='yaml') == {'b': 2}
+
+    arr = np.array([1, 2, 3])
+    store.put('n', arr, fmt='npy')
+    loaded = store.get('n', fmt='npy')
+    assert np.array_equal(loaded, arr)
+
+
+def test_backup_created(tmp_path):
+    store = MemoryStore(tmp_path)
+    store.put('x', {'v': 1})
+    store.put('x', {'v': 2})
+    assert (tmp_path / 'x.json').exists()
+    assert (tmp_path / 'x.json.bak').exists()

--- a/tests/test_memory_store_security.py
+++ b/tests/test_memory_store_security.py
@@ -1,0 +1,21 @@
+import pytest
+
+from eudaimonia.core.memory_store import MemoryStore
+
+
+def test_encryption_round_trip(tmp_path):
+    store = MemoryStore(tmp_path, encrypt=True)
+    store.put('secret', {'value': 42})
+    path = tmp_path / 'secret.json'
+    # plaintext should not be visible
+    assert b'42' not in path.read_bytes()
+    assert store.get('secret')['value'] == 42
+
+
+def test_wrong_key_fails(tmp_path):
+    store = MemoryStore(tmp_path, encrypt=True)
+    store.put('a', {'v': 1})
+    # new store with different key can't decrypt
+    other = MemoryStore(tmp_path, encrypt=True)
+    with pytest.raises(ValueError):
+        other.get('a')


### PR DESCRIPTION
## Summary
- implement `MemoryStore` with JSON/YAML/NumPy persistence and optional encryption
- add `DialogueLoop` that records conversations and stores OpenAI embeddings
- provide interactive CLI `main_loop.py` with YAML configuration
- include default `config.yaml`
- add tests for the new memory store and dialogue loop
- include requirements file

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687176170f04832485f1f7a0039f4b95