### PR TITLE
core deploy/circuit breaker

### DIFF
--- a/svc/app.py
+++ b/svc/app.py
@@ -1,20 +1,100 @@
-from fastapi import FastAPI
+from pathlib import Path
+import os, json
+import yaml
+from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+
 try:
     from eudaimonia.core.router import call_model
 except ImportError:
-    def call_model(text, mode=None):
-        return f"[stubbed router] {text}"
+    def call_model(text, mode=None): return f"[stubbed router] {text}"
+
+# --- load config if present ---
+CFG = {}
+cfg_path = Path("config/router.yaml")
+if cfg_path.exists():
+    CFG = yaml.safe_load(cfg_path.read_text())
+BUDGET_DAILY = float(CFG.get("budget_guard", {}).get("daily_usd", 3.0))
+SOFT_STOP = int(CFG.get("budget_guard", {}).get("soft_stop_pct", 85))
+
+# circuit breaker knobs (fall back to sane defaults)
+CB_ERROR_RATE = float(CFG.get("circuit_breaker", {}).get("error_rate_threshold", 0.25))
+CB_WINDOW_SEC = int(CFG.get("circuit_breaker", {}).get("rolling_seconds", 60))
+CB_OPEN_SEC   = int(CFG.get("circuit_breaker", {}).get("rolling_seconds", 60))
+CB_MIN_EVENTS = 4
+
+# --- bearer auth (optional; enabled if API_TOKEN is set) ---
+API_TOKEN = os.getenv("API_TOKEN")
 
 app = FastAPI()
-from svc.logging_mw import MetricsLogger
-app.add_middleware(MetricsLogger)
 
 class Ask(BaseModel):
     prompt: str
     mode: str | None = None
 
+def require_auth(authorization: str | None):
+    if not API_TOKEN:
+        return
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+    token = authorization.removeprefix("Bearer ").strip()
+    if token != API_TOKEN:
+        raise HTTPException(status_code=403, detail="Invalid token")
+
+# --- logging middleware (append to router_metrics.jsonl) ---
+from svc.logging_mw import MetricsLogger
+app.add_middleware(MetricsLogger)
+
+# --- circuit breaker ---
+from svc.cbreaker import CircuitBreaker
+CB = CircuitBreaker(
+    error_rate_threshold=CB_ERROR_RATE,
+    window_seconds=CB_WINDOW_SEC,
+    open_seconds=CB_OPEN_SEC,
+    min_events=CB_MIN_EVENTS,
+)
+
+def check_soft_budget():
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    total = 0.0
+    logp = Path("router_metrics.jsonl")
+    if logp.exists():
+        for line in logp.read_text(encoding="utf-8", errors="ignore").splitlines():
+            try:
+                j = json.loads(line)
+                if j.get("ts", "")[:10] == today:
+                    total += float(j.get("usd", 0.0))
+            except Exception:
+                continue
+    pct = (total / BUDGET_DAILY * 100.0) if BUDGET_DAILY > 0 else 0.0
+    return pct >= SOFT_STOP, pct, total
+
 @app.post("/v1/ask")
-def ask(q: Ask):
-    out = call_model(q.prompt, mode=q.mode)
-    return {"ok": True, "output": out}
+def ask(q: Ask, authorization: str | None = Header(default=None)):
+    require_auth(authorization)
+
+    # breaker gate: if open, refuse early
+    if not CB.allow():
+        raise HTTPException(status_code=503, detail="Circuit open; please retry shortly.")
+
+    # budget guard
+    stop, pct, total = check_soft_budget()
+    if stop:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Budget soft-stop at {pct:.0f}% (${total:.2f}/{BUDGET_DAILY:.2f})"
+        )
+
+    # forced failure path for testing breaker
+    if q.prompt == "__fail__":
+        CB.record(False)
+        raise HTTPException(status_code=500, detail="Forced failure for breaker test.")
+
+    try:
+        out = call_model(q.prompt, mode=q.mode)
+        CB.record(True)
+        return {"ok": True, "output": out}
+    except Exception:
+        CB.record(False)
+        raise

--- a/svc/cbreaker.py
+++ b/svc/cbreaker.py
@@ -1,0 +1,39 @@
+import time
+from collections import deque
+
+class CircuitBreaker:
+    """
+    Sliding-window breaker.
+    - Trips when error_rate >= thresh and at least min_events seen.
+    - Stays open for open_seconds; during open, .allow() returns False.
+    """
+    def __init__(self, error_rate_threshold=0.25, window_seconds=60, open_seconds=60, min_events=4):
+        self.thresh = float(error_rate_threshold)
+        self.window = int(window_seconds)
+        self.open_seconds = int(open_seconds)
+        self.min_events = int(min_events)
+        self.events = deque()  # (timestamp, ok:bool)
+        self.open_until = 0.0
+
+    def allow(self) -> bool:
+        now = time.time()
+        if now < self.open_until:
+            return False
+        self._gc(now)
+        return True
+
+    def record(self, ok: bool):
+        now = time.time()
+        self.events.append((now, bool(ok)))
+        self._gc(now)
+        total = len(self.events)
+        if total < self.min_events:
+            return
+        errs = sum(1 for _, okv in self.events if not okv)
+        if total and (errs / total) >= self.thresh:
+            self.open_until = now + self.open_seconds
+
+    def _gc(self, now: float):
+        w = self.window
+        while self.events and (now - self.events[0][0]) > w:
+            self.events.popleft()


### PR DESCRIPTION
- **shim+telemetry: decide-only budget guard, JSONL logger, daily aggregator (zero-spend)**
- **metrics: timezone-safe now(); clean timedelta usage; stable 2-decimal spend**
- **config: add router.yaml (budget guard + circuit breaker skeleton)**
- **evals: add minimal golden set + runner**
- **svc: add skinny FastAPI wrapper around router**
- **svc: log each API call to router_metrics.jsonl**
- **ci: run golden evals on PR and upload artifact**
- **dev: add Makefile targets (metrics, evals, api)**
- **svc: add sliding-window circuit breaker (error-rate gate)**
