### PR TITLE
core deploy/tests workflow fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,20 +1,17 @@
 name: tests
-
 on:
-  push:
-    branches: [main]
   pull_request:
-
+    branches: [ "main" ]
 jobs:
-  test:
+  pytest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-      - name: Install dependencies
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
+      - name: Install deps
         run: |
-          pip install .[docs] fastapi uvicorn pytest httpx
-      - name: Run tests
-        run: pytest -v
+          python -m pip install --upgrade pip
+          pip install pytest
+      - name: Run pytest
+        run: pytest -q

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ api:
 
 test:
 	$(PY) -m pytest -q
+
+test:
+	$(PY) -m pytest -q

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,8 @@ evals:
 	$(PY) evals/core/run_evals.py | tee eval_out.jsonl
 
 api:
+	set -a; [ -f .env ] && . ./.env; set +a; \
 	$(PY) -m uvicorn svc.app:app --reload --port 8123
+
+test:
+	$(PY) -m pytest -q

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Eudaimonia MCP
+![ci](https://github.com/Olympianthunder/Eudaimonia-/actions/workflows/ci.yml/badge.svg)
 
 [![CI](https://github.com/OWNER/Eudaimonia-/actions/workflows/tests.yml/badge.svg)](https://github.com/OWNER/Eudaimonia-/actions/workflows/tests.yml)
 [![Docs](https://github.com/OWNER/Eudaimonia-/actions/workflows/docs.yml/badge.svg)](https://OWNER.github.io/Eudaimonia-/)


### PR DESCRIPTION
- **shim+telemetry: decide-only budget guard, JSONL logger, daily aggregator (zero-spend)**
- **metrics: timezone-safe now(); clean timedelta usage; stable 2-decimal spend**
- **config: add router.yaml (budget guard + circuit breaker skeleton)**
- **evals: add minimal golden set + runner**
- **svc: add skinny FastAPI wrapper around router**
- **svc: log each API call to router_metrics.jsonl**
- **ci: run golden evals on PR and upload artifact**
- **dev: add Makefile targets (metrics, evals, api)**
- **svc: add sliding-window circuit breaker (error-rate gate)**
- **ci: add pytest smoke + run golden evals and upload artifact**
- **dev: add Makefile test target**
- **dev: add Makefile test target**
- **docs: add CI badge to README**
- **ci: fix tests workflow to run minimal pytest**
