### PR TITLE
core deploy/docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+__pycache__
+*.pyc
+.env
+.git
+.gitignore
+eval_out.jsonl
+router_metrics.jsonl
+metrics_daily.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.11-slim
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8080
 WORKDIR /app
 COPY . /app
-RUN pip install .[docs] fastapi uvicorn
-CMD ["uvicorn", "eudaimonia.api:app", "--host", "0.0.0.0", "--port", "8000"]
+RUN python -m pip install --upgrade pip && \
+    pip install fastapi uvicorn pyyaml
+EXPOSE 8080
+CMD ["python", "-m", "uvicorn", "svc.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,12 @@ metrics:
 	$(PY) scripts/aggregate_daily.py && cat metrics_daily.json
 
 evals:
+
+docker-build:
+	docker build -t eudaimonia-api:local .
+
+docker-run:
+	docker run --rm -p 8080:8080 -e API_TOKEN=dev-secret-123 eudaimonia-api:local
 	$(PY) evals/core/run_evals.py | tee eval_out.jsonl
 
 api:


### PR DESCRIPTION
- **shim+telemetry: decide-only budget guard, JSONL logger, daily aggregator (zero-spend)**
- **metrics: timezone-safe now(); clean timedelta usage; stable 2-decimal spend**
- **config: add router.yaml (budget guard + circuit breaker skeleton)**
- **evals: add minimal golden set + runner**
- **svc: add skinny FastAPI wrapper around router**
- **svc: log each API call to router_metrics.jsonl**
- **ci: run golden evals on PR and upload artifact**
- **dev: add Makefile targets (metrics, evals, api)**
- **svc: add sliding-window circuit breaker (error-rate gate)**
- **ci: add pytest smoke + run golden evals and upload artifact**
- **dev: add Makefile test target**
- **dev: add Makefile test target**
- **docs: add CI badge to README**
- **ci: fix tests workflow to run minimal pytest**
- **ci: remove legacy tests workflow; use unified ci.yml**
- **ops: add Dockerfile, .dockerignore, and docker build/run targets**
