### PR TITLE
core deploy/router openai

### DIFF
--- a/svc/app.py
+++ b/svc/app.py
@@ -1,32 +1,51 @@
 from pathlib import Path
 import os, json
 import yaml
-from fastapi import FastAPI, Header, HTTPException
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+# --- router import ---
 try:
-    from eudaimonia.core.router import call_model
-except ImportError:
-    def call_model(text, mode=None): return f"[stubbed router] {text}"
+    from svc.providers.router import call_model
+except Exception:
+    # last-resort stub
+    def call_model(prompt: str, mode: str | None = None):
+        return {
+            "text": f"[stubbed router] {prompt}",
+            "usage": {"usd": 0.0, "model": "stub", "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        }
 
-# --- load config if present ---
+# --- config ---
 CFG = {}
 cfg_path = Path("config/router.yaml")
 if cfg_path.exists():
     CFG = yaml.safe_load(cfg_path.read_text())
+
 BUDGET_DAILY = float(CFG.get("budget_guard", {}).get("daily_usd", 3.0))
 SOFT_STOP = int(CFG.get("budget_guard", {}).get("soft_stop_pct", 85))
 
-# circuit breaker knobs (fall back to sane defaults)
 CB_ERROR_RATE = float(CFG.get("circuit_breaker", {}).get("error_rate_threshold", 0.25))
 CB_WINDOW_SEC = int(CFG.get("circuit_breaker", {}).get("rolling_seconds", 60))
 CB_OPEN_SEC   = int(CFG.get("circuit_breaker", {}).get("rolling_seconds", 60))
 CB_MIN_EVENTS = 4
 
-# --- bearer auth (optional; enabled if API_TOKEN is set) ---
 API_TOKEN = os.getenv("API_TOKEN")
 
-app = FastAPI()
+app = FastAPI(title="Eudaimonia Core API", version="1.0")
+
+# CORS
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:3000","http://127.0.0.1:3000",
+        "http://localhost:5173","http://127.0.0.1:5173",
+        "http://localhost:8080","http://127.0.0.1:8080",
+        "*"
+    ],
+    allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
+)
 
 class Ask(BaseModel):
     prompt: str
@@ -41,17 +60,17 @@ def require_auth(authorization: str | None):
     if token != API_TOKEN:
         raise HTTPException(status_code=403, detail="Invalid token")
 
-# --- logging middleware (append to router_metrics.jsonl) ---
+# logging middleware
 from svc.logging_mw import MetricsLogger
 app.add_middleware(MetricsLogger)
 
-# --- circuit breaker ---
+# circuit breaker
 from svc.cbreaker import CircuitBreaker
 CB = CircuitBreaker(
     error_rate_threshold=CB_ERROR_RATE,
     window_seconds=CB_WINDOW_SEC,
     open_seconds=CB_OPEN_SEC,
-    min_events=CB_MIN_EVENTS,
+    min_events=CB_MIN_EVENTS
 )
 
 def check_soft_budget():
@@ -63,38 +82,55 @@ def check_soft_budget():
         for line in logp.read_text(encoding="utf-8", errors="ignore").splitlines():
             try:
                 j = json.loads(line)
-                if j.get("ts", "")[:10] == today:
+                if j.get("ts","")[:10] == today:
                     total += float(j.get("usd", 0.0))
             except Exception:
                 continue
     pct = (total / BUDGET_DAILY * 100.0) if BUDGET_DAILY > 0 else 0.0
     return pct >= SOFT_STOP, pct, total
 
+# unified error shape
+@app.exception_handler(HTTPException)
+async def http_exc_handler(request: Request, exc: HTTPException):
+    code_map = {401:"AUTH_REQUIRED",403:"AUTH_FORBIDDEN",429:"BUDGET_SOFT_STOP",503:"CIRCUIT_OPEN"}
+    code = code_map.get(exc.status_code, "HTTP_ERROR")
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"ok": False, "error": {"code": code, "message": str(exc.detail)}}
+    )
+
+@app.get("/v1/health")
+def health():
+    breaker = "open" if not CB.allow() else "closed"
+    stop, pct, total = check_soft_budget()
+    return {"ok": True, "breaker": breaker, "budget_pct": round(pct,1), "budget_today_usd": round(total, 6)}
+
 @app.post("/v1/ask")
 def ask(q: Ask, authorization: str | None = Header(default=None)):
     require_auth(authorization)
-
-    # breaker gate: if open, refuse early
     if not CB.allow():
         raise HTTPException(status_code=503, detail="Circuit open; please retry shortly.")
-
-    # budget guard
     stop, pct, total = check_soft_budget()
     if stop:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Budget soft-stop at {pct:.0f}% (${total:.2f}/{BUDGET_DAILY:.2f})"
-        )
+        raise HTTPException(status_code=429, detail=f"Budget soft-stop at {pct:.0f}% (${total:.2f}/{BUDGET_DAILY:.2f})")
 
-    # forced failure path for testing breaker
+    # test hook
     if q.prompt == "__fail__":
         CB.record(False)
         raise HTTPException(status_code=500, detail="Forced failure for breaker test.")
 
     try:
-        out = call_model(q.prompt, mode=q.mode)
+        res = call_model(q.prompt, mode=q.mode)  # {"text":..., "usage": {..., "usd": ...}}
+        text = res.get("text","")
+        usage = res.get("usage", {}) or {}
+        usd = float(usage.get("usd", 0.0) or 0.0)
+
+        headers = {"X-USD": str(usd)}
         CB.record(True)
-        return {"ok": True, "output": out}
-    except Exception:
+        return JSONResponse(content={"ok": True, "output": text, "usage": usage}, headers=headers)
+    except HTTPException:
         CB.record(False)
         raise
+    except Exception as e:
+        CB.record(False)
+        return JSONResponse(status_code=500, content={"ok": False, "error": {"code":"INTERNAL_ERROR","message": str(e)}})

--- a/svc/providers/openai_provider.py
+++ b/svc/providers/openai_provider.py
@@ -1,0 +1,53 @@
+import os
+
+def _estimate_usd_from_env(prompt_tokens: int, completion_tokens: int) -> float:
+    """Estimate cost using env-configured per-1k token prices to avoid hardcoding rates."""
+    in_rate = float(os.getenv("MODEL_IN_PRICE_PER_1K", "0") or 0)
+    out_rate = float(os.getenv("MODEL_OUT_PRICE_PER_1K", "0") or 0)
+    usd = (prompt_tokens/1000.0)*in_rate + (completion_tokens/1000.0)*out_rate
+    return round(usd, 6)
+
+def chat_complete(prompt: str, model: str | None = None, temperature: float = 0.2):
+    model = model or os.getenv("MODEL", "gpt-4o-mini")
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set")
+
+    # Try modern SDK first
+    try:
+        from openai import OpenAI  # >=1.x
+        client = OpenAI(api_key=api_key)
+        r = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+        )
+        text = (r.choices[0].message.content or "").strip()
+        usage = getattr(r, "usage", None)
+        if usage is None:
+            pt = ct = tt = 0
+        else:
+            # usage may be a pydantic-like object or dict-ish
+            pt = getattr(usage, "prompt_tokens", None) or getattr(usage, "input_tokens", None) or usage.get("prompt_tokens", 0)
+            ct = getattr(usage, "completion_tokens", None) or getattr(usage, "output_tokens", None) or usage.get("completion_tokens", 0)
+            tt = getattr(usage, "total_tokens", None) or usage.get("total_tokens", (pt or 0) + (ct or 0))
+        usd = _estimate_usd_from_env(pt or 0, ct or 0)
+        return {"text": text, "usage": {"model": model, "prompt_tokens": pt or 0, "completion_tokens": ct or 0, "total_tokens": tt or 0, "usd": usd}}
+    except ImportError:
+        pass  # fall back to legacy
+
+    # Legacy SDK (openai<1.0)
+    import openai  # type: ignore
+    openai.api_key = api_key
+    r = openai.ChatCompletion.create(  # type: ignore
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=temperature,
+    )
+    text = r["choices"][0]["message"]["content"].strip()
+    u = r.get("usage", {}) or {}
+    pt = int(u.get("prompt_tokens", 0))
+    ct = int(u.get("completion_tokens", 0))
+    tt = int(u.get("total_tokens", pt + ct))
+    usd = _estimate_usd_from_env(pt, ct)
+    return {"text": text, "usage": {"model": model, "prompt_tokens": pt, "completion_tokens": ct, "total_tokens": tt, "usd": usd}}

--- a/svc/providers/router.py
+++ b/svc/providers/router.py
@@ -1,0 +1,12 @@
+import os
+from typing import Any, Dict
+
+def _stub(prompt: str, mode: str | None = None) -> Dict[str, Any]:
+    return {"text": f"[stubbed router] {prompt}", "usage": {"model": "stub", "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "usd": 0.0}}
+
+def call_model(prompt: str, mode: str | None = None) -> Dict[str, Any]:
+    router = (os.getenv("ROUTER", "stub") or "stub").lower()
+    if router == "openai":
+        from .openai_provider import chat_complete
+        return chat_complete(prompt, model=os.getenv("MODEL", None))
+    return _stub(prompt, mode)


### PR DESCRIPTION
- **shim+telemetry: decide-only budget guard, JSONL logger, daily aggregator (zero-spend)**
- **metrics: timezone-safe now(); clean timedelta usage; stable 2-decimal spend**
- **config: add router.yaml (budget guard + circuit breaker skeleton)**
- **evals: add minimal golden set + runner**
- **svc: add skinny FastAPI wrapper around router**
- **svc: log each API call to router_metrics.jsonl**
- **ci: run golden evals on PR and upload artifact**
- **dev: add Makefile targets (metrics, evals, api)**
- **svc: add sliding-window circuit breaker (error-rate gate)**
- **ci: add pytest smoke + run golden evals and upload artifact**
- **dev: add Makefile test target**
- **dev: add Makefile test target**
- **docs: add CI badge to README**
- **ci: fix tests workflow to run minimal pytest**
- **ci: remove legacy tests workflow; use unified ci.yml**
- **ops: add Dockerfile, .dockerignore, and docker build/run targets**
- **dev: normalize Makefile (single test target, docker targets)**
- **dev: add Makefile test target**
- **fix: update logging middleware for per-request USD tracking**
- **chore: add .gitignore for env, logs, artifacts**
- **sec: untrack .env and eval_out.jsonl**
- **demo: add single-file web client; ignore env/artifacts**
- **router: OpenAI provider + env-driven router; usage + X-USD wired**
